### PR TITLE
Detach from child process to avoid zombies

### DIFF
--- a/templates/cant_start_app.erb
+++ b/templates/cant_start_app.erb
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Can't start application <%= @app_name %></title>
+  </head>
+  <body>
+    <h1>Can't start application <q><%= @app_name %></q></h1>
+    <p>Please look at <code>/tmp/<%= @app_name %>.log</code> for details</p>
+  </body>
+</html>


### PR DESCRIPTION
Like docs say (http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-spawn) we need to use Process.detach (http://www.ruby-doc.org/core-1.9.3/Process.html#method-c-detach) to avoid zombies. Should solve #2.
