### PR TITLE
Issue #2 Kill all spawned children on daemon EXIT.

### DIFF
--- a/lib/prax/server.rb
+++ b/lib/prax/server.rb
@@ -72,6 +72,7 @@ module Prax
 
     def finalize
       @servers.each { |server| server.close if server }
+      Process.kill 'INT', -Process.getpgrp # Kill all children
       Prax.logger.info("Server shutdown.")
     end
 


### PR DESCRIPTION
Leaving in Process.detach we can kill all processes in the daemons process group.

Tested on OSX but not on linux although should work.
