### PR TITLE
Clean socket files on signal INT, TERM, QUIT.

### DIFF
--- a/lib/prax/server.rb
+++ b/lib/prax/server.rb
@@ -73,10 +73,17 @@ module Prax
       Prax.logger.info("Server shutdown.")
     end
 
+    def finalize_int
+      Dir.glob(Config.socket_root + '/*.sock') do |socket_path|
+        File.unlink socket_path
+      end
+      exit
+    end
+
     def run
-      Signal.trap("INT")  { exit }
-      Signal.trap("TERM") { exit }
-      Signal.trap("QUIT") { exit }
+      Signal.trap("INT")  { finalize_int }
+      Signal.trap("TERM") { finalize_int }
+      Signal.trap("QUIT") { finalize_int }
       Signal.trap("EXIT") { finalize }
 
       Prax.logger.info("HTTP server ready on port #{Config.http_port}")


### PR DESCRIPTION
Socket files were sticking around on INT, TERM and QUIT.

For example running prax in the foreground and then killing with ^C.

This would cause a connection refused error the first time you tried to access an app again after starting prax again as the socket file was there, but there was no racker server listening on the socket.
