### PR TITLE
Spawning racker in rbenv context.

### DIFF
--- a/lib/prax/spawner.rb
+++ b/lib/prax/spawner.rb
@@ -28,15 +28,9 @@ module Prax
     # Spawns the app, then blocks until the socket is ready.
     #
     # TODO: notify an object in the main thread about the spawning app (that
-    # object could kill all apps when prax is terminated, as well as killing
-    # apps after some timeout).
+    # object could kill apps after some timeout).
     def spawn
-      # rbenv
       args, env = [], { 'PATH' => ENV['ORIG_PATH'] }
-      if rbenv?
-        env['RBENV_VERSION'] = nil
-        args += [ "rbenv", "exec" ]
-      end
 
       # bundler
       args += [ "bundle", "exec" ] if gemfile?
@@ -49,7 +43,6 @@ module Prax
         { :out => [ log_path, "a" ], :err => [ :child, :out ] }
       ]
       pid = nil
-
       # FIXME: chdir should happen in racker!
       Dir.chdir(realpath) { pid = Process.spawn(env, *args) }
 
@@ -98,11 +91,6 @@ module Prax
     # Returns true if the app uses Bundler.
     def gemfile?
       File.exists?(File.join(realpath, "Gemfile"))
-    end
-
-    # Returns true if rbenv is found.
-    def rbenv?
-      `which rbenv` != ''
     end
 
     # Path to the Rack config file.


### PR DESCRIPTION
As prax isn't a gem you can't call rbenv exec on racker. The current implementation actually prevents racker form starting with a command not found error if you are using rbenv. rbenv relies on you having the gems installed for each ruby version and calls the bin file from it's shim directory.

This pull request in rbenv https://github.com/sstephenson/rbenv/pull/372 might allow us to change that without prax being a gem but seeing as prax is perhaps heading in the gem direction it might not matter?
