### PR TITLE
support for X-Forwarded-For

### DIFF
--- a/lib/prax/config.rb
+++ b/lib/prax/config.rb
@@ -43,6 +43,10 @@ module Prax
         @threads_count ||= (ENV["PRAX_THREADS"] || 4).to_i
       end
 
+      def x_forward_for
+        @x_forward_for ||= (ENV["PRAX_IP"] || '127.0.0.1')
+      end
+
       # Returns true if a given app is available (a link in host_root that leads
       # to a real directory.
       def configured_app?(app_name)

--- a/lib/prax/handler.rb
+++ b/lib/prax/handler.rb
@@ -94,6 +94,7 @@ module Prax
     def pass_request
       @request.each do |line|
         @output.write("X-Forwarded-Proto: https\r\n") if line.strip.empty? and @ssl
+        @output.write("X-Forwarded-For: \"#{Config.x_forward_for}\"\r\n") if line.strip.empty?
         @output.write(line)
       end
       content_length = @request_headers["content-length"].to_i


### PR DESCRIPTION
one can change default ip from 127.0.0.1 to any ip with PRAX_IP eg:

```
$ export PRAX_IP=192.168.240.80; prax stop && prax start
```

fixes #27
