### PR TITLE
Forwards the REMOTE_ADDR in the proxy

### DIFF
--- a/lib/prax/handler.rb
+++ b/lib/prax/handler.rb
@@ -73,6 +73,10 @@ module Prax
 
       if line and line.strip =~ %r{^([A-Z]+) (.+) (HTTP/\d\.\d)$}
         @request << line
+
+        # remote address
+        @request << "Remote-Addr: #{@input.peeraddr[3]}\r\n"
+
         @http_method  = $1
         @request_uri  = $2
         @http_version = $3

--- a/lib/racker/parser.rb
+++ b/lib/racker/parser.rb
@@ -12,7 +12,6 @@ module Racker
 
     def to_env
       default_env
-      parse_remote_addr
       parse_request_line
       parse_query_string
       parse_headers
@@ -33,11 +32,6 @@ module Racker
         @env["rack.errors"] = STDERR
         @env["rack.logger"] = Racker.logger
         @env["rack.url_scheme"] = "http"
-      end
-
-      def parse_remote_addr
-        _, _, host = socket.peeraddr
-        @env["REMOTE_ADDR"] = host
       end
 
       def parse_request_line
@@ -66,6 +60,7 @@ module Racker
           if line.strip =~ /^([^:]*):\s*(.*)$/
             value, key = $2, $1.upcase.gsub("-", "_")
             case key
+            when "REMOTE_ADDR"    then @env["REMOTE_ADDR"]    = value
             when "CONTENT_TYPE"   then @env["CONTENT_TYPE"]   = value
             when "CONTENT_LENGTH" then @env["CONTENT_LENGTH"] = value.to_i
             else @env["HTTP_#{key}"] = value


### PR DESCRIPTION
Relates to ysbaddaden/prax#32

I was thinking if the proxy shouldn't be responsible from setting the REMOTE_ADDR header and forwarding that to the UNIX socket, as we have the address info at that time. Thoughts?
