### PR TITLE
Add prax to front of resolver list

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -83,19 +83,16 @@ Eventually <tt>bin/prax start</tt> to run Prax, point your browser to
 
 ==== Slowness
 
-If you experience some regular slowness, where Prax seems to hang for periods
-of 5 seconds, this is because of the DNS resolution: NSSwitch tries a real DNS
-resolution before checking the prax extension. This usually creates an overhead
-of less than half a second, but sometimes takes 5 seconds on my Ubuntu 12.04.
+If you notice regular web browsing or any kind of DNS resolution being slower
+than usual, this might be due to the prax NSSwitch extension.
 
-You may try to move the `prax` NSSwitch extension before the `dns` one, so it
-looks like this:
+You may try to move the `prax` NSSwitch extension _after_ the `dns` one, so it
+looks like this (in /etc/nsswitch.conf):
 
-  hosts: files mdns4_minimal [NOTFOUND=return] prax dns mdns4
+  hosts: files mdns4_minimal [NOTFOUND=return] dns prax mdns4
 
-This will dramatically speed up the DNS resolution of *.dev domains, and it
-should never hang anymore. BUT please be aware that it may cause problems in
-regular DNS resolutions!
+Which should solve the problem, BUT might cause prax itself to resolve .dev domains
+a few seconds slower.
 
 === Mac OS X
 

--- a/libexec/prax-install
+++ b/libexec/prax-install
@@ -13,7 +13,7 @@ make
 sudo make install
 
 echo 'Adding "prax" to the hosts line of /etc/nsswitch.conf'
-sudo sed -i -r -e '/\bprax\b/ !s/^hosts:(\s+)/hosts:\1prax /' /etc/nsswitch.conf
+sudo sed -i -r -e '/\bprax\b/ !s/^hosts:(.+)dns/hosts:\1prax dns/' /etc/nsswitch.conf
 
 cd $PRAX_ROOT
 echo "Installing Prax firewall rule"


### PR DESCRIPTION
May I suggest defaulting to have resolve prax first? On my very vanilla Debian Wheezy VM prax regularly takes more than 5 seconds to resolve, and it's just painful. Putting it before regular DNS resolution doesn't seem to have any negative impacts on normal browsing.
