### PR TITLE
set $HOME in server env

### DIFF
--- a/lib/prax/application.rb
+++ b/lib/prax/application.rb
@@ -117,7 +117,7 @@ module Prax
       end
 
       def env
-        { 'PATH' => ENV['ORIG_PATH'], 'PRAX_DEBUG' => ENV['PRAX_DEBUG'] }
+        { 'PATH' => ENV['ORIG_PATH'], 'PRAX_DEBUG' => ENV['PRAX_DEBUG'], 'HOME' => ENV['HOME'] }
       end
 
       def command


### PR DESCRIPTION
Some gems (i.e. pry) expect ENV['HOME'] to be set. Apps that use these gems can't startup otherwise through prax.
