### PR TITLE
allow setting of number of worker threads

### DIFF
--- a/lib/prax/config.rb
+++ b/lib/prax/config.rb
@@ -38,6 +38,10 @@ module Prax
         @threads_count ||= (ENV["PRAX_THREADS"] || 16).to_i
       end
 
+      def worker_threads_count
+        @worker_threads_count ||= (ENV["PRAX_APP_THREADS"] || 4).to_i
+      end
+
       # Time after which an inactive app may be killed, in minutes. Defaults to
       # 10 minutes.
       def ttl

--- a/lib/racker.rb
+++ b/lib/racker.rb
@@ -3,6 +3,7 @@ require 'rack/builder'
 require 'prax/microserver'
 require 'prax/worker'
 require 'prax/logger'
+require 'prax/config'
 require 'racker/handler'
 
 module Racker
@@ -38,7 +39,7 @@ module Racker
     include Prax::Worker
 
     self.worker_class = Pool
-    self.worker_size = 4
+    self.worker_size = Prax::Config.worker_threads_count
 
     def started
       servers = @listeners.map do |server|


### PR DESCRIPTION
This allows setting the # of per-app worker threads through the `PRAX_APP_THREADS` envvar, and lets non-threadsafe code run correctly by setting that value to 1.

All the tests pass. (Proxy#test_0006_supports bundler with special gems fails for me but it also fails on the base unstable branch)
