### PR TITLE
explicitly look for 'dns' in nsswitch.conf

### DIFF
--- a/libexec/prax-install
+++ b/libexec/prax-install
@@ -13,7 +13,7 @@ sudo make
 sudo make install
 
 echo 'Adding "prax" to the hosts line of /etc/nsswitch.conf'
-sudo sed -i -r -e '/\bprax\b/ !s/^hosts:(.+)dns/hosts:\1prax dns/' /etc/nsswitch.conf
+sudo sed -i -r -e '/\bprax\b/ !s/^hosts:(.+)\bdns\b/hosts:\1prax dns/' /etc/nsswitch.conf
 
 cd $PRAX_ROOT
 echo "Installing Prax firewall rule"


### PR DESCRIPTION
Current installation is broken on Ubuntu because it will replace the default

```
hosts:          files mdns4_minimal [NOTFOUND=return] dns mdns4
```

with

```
hosts:          files mdns4_minimal [NOTFOUND=return] dns mprax dns4
```

This patch fixes that.
