### PR TITLE
Generate SSL files in the correct place

### DIFF
--- a/libexec/prax-install
+++ b/libexec/prax-install
@@ -29,7 +29,9 @@ echo "Symlinking prax into /usr/local/bin"
 sudo ln -sf "$PRAX_ROOT/bin/prax" /usr/local/bin/prax
 
 echo "Generating SSL key and certificate"
-./ssl/generate.sh
+cd ./ssl/
+./generate.sh
+cd - > /dev/null
 
 echo "Starting prax server"
 prax start


### PR DESCRIPTION
We are expecting the SSL files to live in the `ssl` directory. Since `generate.sh` creates those files in the current working directory, and we shouldn't change that behavior, we need to be in the `ssl` directory when we invoke `generate.sh` during installation.
