### PR TITLE
Target iptables rules for external requests

### DIFF
--- a/install/initd
+++ b/install/initd
@@ -16,14 +16,18 @@ NAME=prax
 DESC="Prax Rack server (iptables configuration)."
 HTTP_PORT=20559
 HTTPS_PORT=20558
+DEVICES=$(ifconfig | egrep '^(wlan|eth)[0-9]+' | cut -f1 -d ' ')
 
 case "$1" in
   start)
     if [ `iptables -t nat -L -n | egrep "($HTTP_PORT|$HTTPS_PORT)" | wc -l` -eq 0 ] ; then
       iptables -t nat -A OUTPUT -p tcp -d 127.0.0.1 --dport 80  -j REDIRECT --to-ports $HTTP_PORT
       iptables -t nat -A OUTPUT -p tcp -d 127.0.0.1 --dport 443 -j REDIRECT --to-ports $HTTPS_PORT
-      iptables -t nat -A PREROUTING -p tcp  --dport 80 -j REDIRECT --to-port $HTTP_PORT
-      iptables -t nat -A PREROUTING -p tcp  --dport 443 -j REDIRECT --to-port $HTTPS_PORT
+
+      for device in $DEVICES; do
+        iptables -t nat -A PREROUTING -p tcp -i $device --dport 80  -j REDIRECT --to-port $HTTP_PORT
+        iptables -t nat -A PREROUTING -p tcp -i $device --dport 443 -j REDIRECT --to-port $HTTPS_PORT
+      done
     fi
     ;;
   stop)
@@ -39,5 +43,8 @@ case "$1" in
   restart)
     $0 stop
     $0 start
+    ;;
+  status)
+    iptables -t nat -L -n
     ;;
 esac


### PR DESCRIPTION
The PREROUTING rules aren't behaving properly since Ubuntu 14.04 and some users have routing problems with Docker. 

These rules are meant to redirect the external requests from ports 80 and 443 to ports 20559 and 20558 since Prax runs with user privileges it can't listen on these ports, and it's cumbersome to handle manual ports in URL —for the developer and sometimes in the application's code too.

I changed the existing rules to target the `eth*` and `wlan*` devices specifically, instead of prerouting everything. Let me know if you encounter any problem (or not) with these new rules.

Relates to #87 and #102 
