### PR TITLE
Config response timeout

### DIFF
--- a/lib/prax/config.rb
+++ b/lib/prax/config.rb
@@ -34,6 +34,12 @@ module Prax
         @https_port ||= (ENV["PRAX_HTTPS_PORT"] || 20558).to_i
       end
 
+      # Seconds to wait for a Rack application to return response headers before
+      # failing the user request
+      def response_timeout
+        @response_timeout ||= (ENC["PRAX_RESPONSE_TIMEOUT"] || 60).to_i
+      end
+
       def threads_count
         @threads_count ||= (ENV["PRAX_THREADS"] || 16).to_i
       end

--- a/lib/prax/config.rb
+++ b/lib/prax/config.rb
@@ -37,7 +37,7 @@ module Prax
       # Seconds to wait for a Rack application to return response headers before
       # failing the user request
       def response_timeout
-        @response_timeout ||= (ENC["PRAX_RESPONSE_TIMEOUT"] || 60).to_i
+        @response_timeout ||= (ENV["PRAX_RESPONSE_TIMEOUT"] || 60).to_i
       end
 
       def threads_count

--- a/lib/prax/response.rb
+++ b/lib/prax/response.rb
@@ -1,3 +1,4 @@
+require 'prax/config'
 require 'prax/http'
 
 module Prax
@@ -13,7 +14,9 @@ module Prax
     end
 
     def parse_response
-      timeout(60) { parse_http_headers if @status_line = socket.gets }
+      timeout(Config.response_timeout) do
+        parse_http_headers if @status_line = socket.gets
+      end
     rescue
       # NOTE: it may fail because the port-forwarded app isn't reachable
       raise CantStartApp.new


### PR DESCRIPTION
Replace hardcoded 60-second Rack app response header timeout with configuration variable and 60-second default. Motivation: 60 seconds is insufficient for starting up complex applications, particularly in development scenarios using cheap computing platforms (e.g. small EC2 instance types). Allow users option to adjust timeout for specific circumstances.